### PR TITLE
[WiP] Add experimental support for IDE protocol.

### DIFF
--- a/src/client/app/pages/editor/components/device-toolbar/device-toolbar.component.ts
+++ b/src/client/app/pages/editor/components/device-toolbar/device-toolbar.component.ts
@@ -68,8 +68,9 @@ export class DeviceToolbarComponent implements AfterViewInit {
 
         this.webusbService.connect()
         .then(() => {
-            this.appDataService.term.io.print('\r\nConnection established\r\n');
-            this.webusbService.send('\n'); // Force getting a prompt
+            this.appDataService.term.io.print('\r\nConnection established.\r\n');
+            this.webusbService.init();
+
             this.onSuccess.emit({
                 header: 'Success',
                 body: 'You are now connected to the USB device'

--- a/src/client/app/shared/webusb/webusb.service.ts
+++ b/src/client/app/shared/webusb/webusb.service.ts
@@ -107,6 +107,10 @@ export class WebUsbService {
         return this.port.send(data);
     }
 
+    public init() {
+        this.port.init();
+    }
+
     public run(data: string): Promise<string> {
         let throttle = this.settingsService.getDeviceThrottle();
         return this.port.run(data, throttle);


### PR DESCRIPTION
Add support for the IDE protocol implemented [here](https://github.com/01org/zephyr.js/pull/1719).
This is for preliminary testing of the feature, expect changes.

Behavior can be switched between the old console mode and new IDE protocol mode by setting `ideMode` in `WebUsbPort` class.

There is code for preparing support for raw WebUSB transport (interface 0). Currently WebUSB over UART is used (interface 2). 

Testing can happen in the following ways:
- by entering IDE commands in the console window (e.g. `{run blink.js}`)
- by pressing the IDE buttons (the Save button works, the Run button does not, since the Run functionality has changed: it takes a file name, not a stream). 
- The current Run functionality could be actually implemented, by first saving to a temporary file, then running that file. However, on WebUsbPort level the functions remains the current one, the old behavior should be done on a higher layer, e.g. device-toolbar code. This is not included in this PR.

Signed-off-by: Zoltan Kis <zoltan.kis@intel.com>
