### PR TITLE
Fix for protractor tests.

### DIFF
--- a/src/e2e/specs/app.component.e2e-spec.ts
+++ b/src/e2e/specs/app.component.e2e-spec.ts
@@ -13,13 +13,18 @@ describe('App', () => {
     it('should have <nav>', async () => {
         expect(await element(by.css('sd-navbar nav')).isPresent()).toEqual(true);
     });
+});
+
+describe('App part 2', () => {
+    beforeEach(async () => {
+        return await browser.get('/#/editor');
+    });
 
     it('routing should preserve editor tabs', () => {
         let tabs;
 
         // Initial check
         browser.ignoreSynchronization = true;
-        browser.get('/#/editor');
         tabs = element.all(by.css('sd-editor .left-component a.nav-link'));
         expect(tabs.count()).toEqual(1);
 


### PR DESCRIPTION
Protractor was hanging on async calls because the editor wasn't visible yet.
Adding a wait fixes this issue.
Signed-off-by: Brian J Jones <brian.j.jones@intel.com>