### PR TITLE
Adding an additional check for saving to device

### DIFF
--- a/src/client/app/pages/editor/components/device-toolbar/device-toolbar.component.ts
+++ b/src/client/app/pages/editor/components/device-toolbar/device-toolbar.component.ts
@@ -282,7 +282,7 @@ export class DeviceToolbarComponent implements AfterViewInit {
         let extlen = fnsplit[1] ? fnsplit[1].length : 0;
 
         // Check the filename is in 8.3 format or not.
-        if (namelen === 0 || namelen > 8 || extlen > 3) {
+        if (namelen === 0 || namelen > 8 || extlen > 3 || extlen < 1) {
             return false;
         }
 


### PR DESCRIPTION
Now it will also check the file name has an extension,
not just if the extension is too long. Fix for 242.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>