### PR TITLE
Docs: add pointer to security reporting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Please see the
 [CONTRIBUTING](https://github.com/intel/zephyrjs-ide/blob/master/.github/CONTRIBUTING.md)
 file for guidelines.
 
+To report a security issue, please follow the procedure described [here](https://01.org/security).
+
 # License
 
 Apache 2.0


### PR DESCRIPTION
Add a note to the README file directing users to the security reporting guidelines on 01.org.